### PR TITLE
Add opt-in Zenith Sun Gong cue at solar noon

### DIFF
--- a/app/src/main/java/com/rooster/rooster/presentation/compose/SettingsScreen.kt
+++ b/app/src/main/java/com/rooster/rooster/presentation/compose/SettingsScreen.kt
@@ -103,6 +103,7 @@ fun SettingsScreen(
     var dynamicColorsEnabled by remember { mutableStateOf(ThemeHelper.isDynamicColorsEnabled(context)) }
     var solarSoundEnabled by remember { mutableStateOf(SolarEventPrefs.isSoundEnabled(context)) }
     var solarVibrationEnabled by remember { mutableStateOf(SolarEventPrefs.isVibrationEnabled(context)) }
+    var zenithGongEnabled by remember { mutableStateOf(SolarEventPrefs.isZenithGongEnabled(context)) }
 
     val coroutineScope = rememberCoroutineScope()
     var smartWake by remember { mutableStateOf(SmartWakePrefs.get(context)) }
@@ -229,6 +230,21 @@ fun SettingsScreen(
                             onCheckedChange = { checked ->
                                 solarVibrationEnabled = checked
                                 SolarEventPrefs.setVibrationEnabled(context, checked)
+                                rescheduleSolarEventCues(context)
+                            },
+                        )
+                    },
+                )
+                Divider()
+                SettingRow(
+                    title = "Zenith Sun Gong",
+                    description = "A deep gong at solar noon, replacing the standard bell",
+                    trailing = {
+                        Switch(
+                            checked = zenithGongEnabled,
+                            onCheckedChange = { checked ->
+                                zenithGongEnabled = checked
+                                SolarEventPrefs.setZenithGongEnabled(context, checked)
                                 rescheduleSolarEventCues(context)
                             },
                         )

--- a/app/src/main/java/com/rooster/rooster/receiver/SolarEventReceiver.kt
+++ b/app/src/main/java/com/rooster/rooster/receiver/SolarEventReceiver.kt
@@ -3,11 +3,13 @@ package com.rooster.rooster.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.rooster.rooster.util.AppConstants
 import com.rooster.rooster.util.Logger
 import com.rooster.rooster.util.SolarEventPrefs
 import com.rooster.rooster.util.SolarEventScheduler
 import com.rooster.rooster.util.SolarEventTone
 import com.rooster.rooster.util.SolarEventVibration
+import com.rooster.rooster.util.ZenithGongTone
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -29,7 +31,9 @@ class SolarEventReceiver : BroadcastReceiver() {
 
         val soundOn = SolarEventPrefs.isSoundEnabled(context)
         val vibrateOn = SolarEventPrefs.isVibrationEnabled(context)
-        Logger.i(TAG, "Solar event fired: $event (sound=$soundOn, vibrate=$vibrateOn)")
+        val gongOn = SolarEventPrefs.isZenithGongEnabled(context) &&
+            event == AppConstants.SOLAR_EVENT_SOLAR_NOON
+        Logger.i(TAG, "Solar event fired: $event (sound=$soundOn, vibrate=$vibrateOn, gong=$gongOn)")
 
         // Reschedule the next event regardless of whether anything plays —
         // we want the chain to keep advancing even if the user has muted.
@@ -39,17 +43,16 @@ class SolarEventReceiver : BroadcastReceiver() {
                 .onFailure { Logger.e(TAG, "Failed to reschedule after event", it) }
         }
 
-        if (!soundOn && !vibrateOn) return
-
-        val toneMs = if (soundOn) SolarEventTone.durationMsFor(event) else 0L
-        val vibMs = if (vibrateOn) SolarEventVibration.durationMsFor(event) else 0L
-        if (toneMs == 0L && vibMs == 0L) return
+        // At noon, the gong takes the place of the bell so the two don't overlap.
+        val playBell = soundOn && !gongOn
+        if (!playBell && !vibrateOn && !gongOn) return
 
         val pendingResult = goAsync()
         scope.launch {
             try {
                 if (vibrateOn) SolarEventVibration.vibrate(appContext, event)
-                if (soundOn) SolarEventTone.play(event)
+                if (gongOn) ZenithGongTone.play()
+                else if (playBell) SolarEventTone.play(event)
             } catch (e: Exception) {
                 Logger.e(TAG, "Error playing solar event cue", e)
             } finally {

--- a/app/src/main/java/com/rooster/rooster/util/SolarEventPrefs.kt
+++ b/app/src/main/java/com/rooster/rooster/util/SolarEventPrefs.kt
@@ -6,12 +6,17 @@ import android.content.Context
  * On/off toggles for the solar-event cue. Sound and vibration are
  * independent: a user can leave only one enabled. Defaults are ON for both
  * — the cue is the headline feature this setting governs.
+ *
+ * The Zenith Sun Gong is a separate, opt-in cue: when enabled, the standard
+ * noon bell is replaced by a deep gong strike. It can fire even with sound
+ * disabled — a user can choose to hear only the gong at solar noon.
  */
 object SolarEventPrefs {
 
     private const val PREFS_NAME = "rooster_prefs"
     private const val KEY_SOUND = "solar_event_sound_enabled"
     private const val KEY_VIBRATION = "solar_event_vibration_enabled"
+    private const val KEY_ZENITH_GONG = "solar_event_zenith_gong_enabled"
 
     fun isSoundEnabled(context: Context): Boolean =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -31,6 +36,15 @@ object SolarEventPrefs {
             .edit().putBoolean(KEY_VIBRATION, enabled).apply()
     }
 
+    fun isZenithGongEnabled(context: Context): Boolean =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_ZENITH_GONG, false)
+
+    fun setZenithGongEnabled(context: Context, enabled: Boolean) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_ZENITH_GONG, enabled).apply()
+    }
+
     fun isAnyEnabled(context: Context): Boolean =
-        isSoundEnabled(context) || isVibrationEnabled(context)
+        isSoundEnabled(context) || isVibrationEnabled(context) || isZenithGongEnabled(context)
 }

--- a/app/src/main/java/com/rooster/rooster/util/SolarEventScheduler.kt
+++ b/app/src/main/java/com/rooster/rooster/util/SolarEventScheduler.kt
@@ -45,9 +45,15 @@ object SolarEventScheduler {
         cancelAll(context)
 
         if (!SolarEventPrefs.isAnyEnabled(context)) {
-            Logger.d(TAG, "Both sound and vibration disabled — nothing to schedule")
+            Logger.d(TAG, "All solar cues disabled — nothing to schedule")
             return
         }
+
+        // When only the Zenith Sun Gong is on (no general sound/vibration), we
+        // only need solar noon scheduled — skip the other eight events entirely.
+        val gongOnlyMode = SolarEventPrefs.isZenithGongEnabled(context) &&
+            !SolarEventPrefs.isSoundEnabled(context) &&
+            !SolarEventPrefs.isVibrationEnabled(context)
 
         val today = astronomyRepository?.getAstronomyData(forceRefresh = false)
         val now = System.currentTimeMillis()
@@ -55,7 +61,9 @@ object SolarEventScheduler {
 
         if (today != null) {
             for ((event, time) in eventTimes(today)) {
-                if (time > now) upcoming += event to time
+                if (time <= now) continue
+                if (gongOnlyMode && event != AppConstants.SOLAR_EVENT_SOLAR_NOON) continue
+                upcoming += event to time
             }
         }
 
@@ -72,7 +80,9 @@ object SolarEventScheduler {
                     Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 1) }
                 )
                 for ((event, time) in eventTimes(tomorrow)) {
-                    if (time > now) upcoming += event to time
+                    if (time <= now) continue
+                    if (gongOnlyMode && event != AppConstants.SOLAR_EVENT_SOLAR_NOON) continue
+                    upcoming += event to time
                 }
             }
         }

--- a/app/src/main/java/com/rooster/rooster/util/ZenithGongTone.kt
+++ b/app/src/main/java/com/rooster/rooster/util/ZenithGongTone.kt
@@ -1,0 +1,100 @@
+package com.rooster.rooster.util
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import kotlin.math.PI
+import kotlin.math.exp
+import kotlin.math.sin
+
+/**
+ * Single deep gong strike for solar noon. Distinct from [SolarEventTone]'s
+ * struck-bowl bells: lower fundamental (~A2), inharmonic partials, slow
+ * shimmering attack, and a long ~6-second decay. The non-integer partial
+ * ratios produce the metallic beating character of a real bronze gong.
+ */
+object ZenithGongTone {
+
+    private const val FUNDAMENTAL_HZ = 110.0
+    private const val SAMPLE_RATE = 44100
+    private const val DURATION_SEC = 6.0
+    private const val ATTACK_SEC = 0.12
+    private const val GAIN = 0.22f
+
+    private val partials = listOf(
+        Partial(ratio = 1.000, amp = 1.00, tau = 2.8),
+        Partial(ratio = 1.498, amp = 0.55, tau = 2.2),
+        Partial(ratio = 2.276, amp = 0.42, tau = 1.7),
+        Partial(ratio = 3.012, amp = 0.30, tau = 1.3),
+        Partial(ratio = 4.413, amp = 0.18, tau = 0.9),
+        Partial(ratio = 5.802, amp = 0.10, tau = 0.6)
+    )
+
+    /** Total ms to allow the receiver to stay alive while the gong rings out. */
+    fun durationMs(): Long = (DURATION_SEC * 1000).toLong() + 200L
+
+    /**
+     * Synthesize and play one gong strike. Blocks the calling thread for the
+     * full duration — call from a worker thread inside goAsync().
+     */
+    fun play() {
+        val durationMs = (DURATION_SEC * 1000).toInt()
+        val track = buildGongTrack(durationMs) ?: return
+        try {
+            track.play()
+            Thread.sleep(durationMs.toLong())
+        } finally {
+            runCatching { track.stop() }
+            runCatching { track.release() }
+        }
+    }
+
+    private fun buildGongTrack(durationMs: Int): AudioTrack? {
+        val totalSamples = (SAMPLE_RATE * durationMs / 1000).coerceAtLeast(1)
+        val buffer = ShortArray(totalSamples)
+        val attackSamples = (SAMPLE_RATE * ATTACK_SEC).toInt().coerceAtLeast(1)
+
+        for (i in 0 until totalSamples) {
+            val t = i.toDouble() / SAMPLE_RATE
+            var sample = 0.0
+            for (p in partials) {
+                sample += p.amp * exp(-t / p.tau) *
+                    sin(2 * PI * FUNDAMENTAL_HZ * p.ratio * t)
+            }
+            // Slow shimmer attack — the strike "opens up" instead of cracking.
+            val attack = if (i < attackSamples) {
+                val x = i.toDouble() / attackSamples
+                x * x
+            } else {
+                1.0
+            }
+            buffer[i] = (sample * attack * GAIN * Short.MAX_VALUE).toInt()
+                .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+                .toShort()
+        }
+
+        val byteSize = buffer.size * 2
+        return runCatching {
+            AudioTrack.Builder()
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .build()
+                )
+                .setAudioFormat(
+                    AudioFormat.Builder()
+                        .setSampleRate(SAMPLE_RATE)
+                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                        .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                        .build()
+                )
+                .setBufferSizeInBytes(byteSize)
+                .setTransferMode(AudioTrack.MODE_STATIC)
+                .build()
+                .also { it.write(buffer, 0, buffer.size) }
+        }.getOrNull()
+    }
+
+    private data class Partial(val ratio: Double, val amp: Double, val tau: Double)
+}


### PR DESCRIPTION
## Summary
- New `ZenithGongTone` synthesizes a deep gong strike (A2 fundamental, inharmonic partials, ~6s decay) — distinct from the existing 3-note struck-bowl bells.
- Adds a "Zenith Sun Gong" toggle under **Settings → Solar Event Cues** (default off). When enabled, the standard noon bell is replaced by the gong so the two don't overlap.
- Gong is independent of the general sound toggle: if it's the only cue enabled, the scheduler runs in noon-only mode and skips the other eight events.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Pre-commit `./gradlew build` passes
- [ ] On-device: enable gong, confirm a deep ~6s gong fires at solar noon and no bell overlaps
- [ ] On-device: disable general sound, leave only gong on — confirm noon still fires, other events stay silent
- [ ] On-device: disable everything — confirm scheduler cancels all alarms

🤖 Generated with [Claude Code](https://claude.com/claude-code)