### PR TITLE
Add zenith window notification + tap-to-preview gong

### DIFF
--- a/app/src/main/java/com/rooster/rooster/RoosterApplication.kt
+++ b/app/src/main/java/com/rooster/rooster/RoosterApplication.kt
@@ -167,10 +167,24 @@ class RoosterApplication : Application(), Configuration.Provider {
                 description = "Notifications for background location and astronomy updates"
                 setShowBadge(false)
             }
-            
+
+            // Zenith window notification channel — silent (the gong handles audio,
+            // we trigger the unique vibration ourselves).
+            val zenithChannel = NotificationChannel(
+                ZENITH_CHANNEL_ID,
+                "Zenith Window",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Notification shown around solar noon"
+                enableVibration(false)
+                setShowBadge(false)
+                setSound(null, null)
+            }
+
             val notificationManager = getSystemService(NotificationManager::class.java)
             notificationManager.createNotificationChannel(alarmChannel)
             notificationManager.createNotificationChannel(workChannel)
+            notificationManager.createNotificationChannel(zenithChannel)
         }
     }
     
@@ -186,5 +200,6 @@ class RoosterApplication : Application(), Configuration.Provider {
     companion object {
         const val ALARM_CHANNEL_ID = "alarm_channel"
         const val WORK_CHANNEL_ID = "work_channel"
+        const val ZENITH_CHANNEL_ID = "zenith_channel"
     }
 }

--- a/app/src/main/java/com/rooster/rooster/presentation/compose/SettingsScreen.kt
+++ b/app/src/main/java/com/rooster/rooster/presentation/compose/SettingsScreen.kt
@@ -56,6 +56,7 @@ import com.rooster.rooster.util.SmartWakePrefs
 import com.rooster.rooster.util.SmartWakeScheduler
 import com.rooster.rooster.util.SolarEventPrefs
 import com.rooster.rooster.util.ThemeHelper
+import com.rooster.rooster.util.ZenithGongTone
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -238,7 +239,8 @@ fun SettingsScreen(
                 Divider()
                 SettingRow(
                     title = "Zenith Sun Gong",
-                    description = "A deep gong at solar noon, replacing the standard bell",
+                    description = "A deep gong at solar noon, replacing the standard bell · tap to preview",
+                    onClick = { previewZenithGong() },
                     trailing = {
                         Switch(
                             checked = zenithGongEnabled,
@@ -246,6 +248,7 @@ fun SettingsScreen(
                                 zenithGongEnabled = checked
                                 SolarEventPrefs.setZenithGongEnabled(context, checked)
                                 rescheduleSolarEventCues(context)
+                                if (checked) previewZenithGong()
                             },
                         )
                     },
@@ -827,6 +830,14 @@ private fun rescheduleSolarEventCues(context: android.content.Context) {
         runCatching {
             com.rooster.rooster.util.SolarEventScheduler.scheduleUpcoming(context.applicationContext)
         }
+    }
+}
+
+private fun previewZenithGong() {
+    // Play one strike off the main thread so the UI stays responsive while
+    // the ~6s gong rings out — same synthesis the receiver uses at noon.
+    kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+        runCatching { ZenithGongTone.play() }
     }
 }
 

--- a/app/src/main/java/com/rooster/rooster/receiver/SolarEventReceiver.kt
+++ b/app/src/main/java/com/rooster/rooster/receiver/SolarEventReceiver.kt
@@ -10,6 +10,8 @@ import com.rooster.rooster.util.SolarEventScheduler
 import com.rooster.rooster.util.SolarEventTone
 import com.rooster.rooster.util.SolarEventVibration
 import com.rooster.rooster.util.ZenithGongTone
+import com.rooster.rooster.util.ZenithNotification
+import com.rooster.rooster.util.ZenithVibration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -23,6 +25,19 @@ import kotlinx.coroutines.launch
 class SolarEventReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
+        val appContext = context.applicationContext
+
+        if (intent.action == ACTION_ZENITH_WINDOW_START) {
+            Logger.i(TAG, "Zenith window opening — posting notification + tactile signature")
+            ZenithNotification.show(appContext)
+            // Reschedule so tomorrow's zenith window gets queued up.
+            scope.launch {
+                runCatching { SolarEventScheduler.scheduleUpcoming(appContext) }
+                    .onFailure { Logger.e(TAG, "Failed to reschedule after zenith window", it) }
+            }
+            return
+        }
+
         if (intent.action != ACTION_SOLAR_EVENT) return
         val event = intent.getStringExtra(EXTRA_EVENT) ?: run {
             Logger.w(TAG, "Solar event broadcast missing event extra")
@@ -37,7 +52,6 @@ class SolarEventReceiver : BroadcastReceiver() {
 
         // Reschedule the next event regardless of whether anything plays —
         // we want the chain to keep advancing even if the user has muted.
-        val appContext = context.applicationContext
         scope.launch {
             runCatching { SolarEventScheduler.scheduleUpcoming(appContext) }
                 .onFailure { Logger.e(TAG, "Failed to reschedule after event", it) }
@@ -50,9 +64,16 @@ class SolarEventReceiver : BroadcastReceiver() {
         val pendingResult = goAsync()
         scope.launch {
             try {
-                if (vibrateOn) SolarEventVibration.vibrate(appContext, event)
-                if (gongOn) ZenithGongTone.play()
-                else if (playBell) SolarEventTone.play(event)
+                if (gongOn) {
+                    // Unique tactile signature paired with the gong, so the user
+                    // still feels the moment when audio is suppressed. Replaces
+                    // the standard noon "crown peal" vibration.
+                    ZenithVibration.vibrate(appContext)
+                    ZenithGongTone.play()
+                } else {
+                    if (vibrateOn) SolarEventVibration.vibrate(appContext, event)
+                    if (playBell) SolarEventTone.play(event)
+                }
             } catch (e: Exception) {
                 Logger.e(TAG, "Error playing solar event cue", e)
             } finally {
@@ -63,6 +84,7 @@ class SolarEventReceiver : BroadcastReceiver() {
 
     companion object {
         const val ACTION_SOLAR_EVENT = "com.rooster.rooster.ACTION_SOLAR_EVENT"
+        const val ACTION_ZENITH_WINDOW_START = "com.rooster.rooster.ACTION_ZENITH_WINDOW_START"
         const val EXTRA_EVENT = "solar_event"
         private const val TAG = "SolarEventReceiver"
 

--- a/app/src/main/java/com/rooster/rooster/util/AppConstants.kt
+++ b/app/src/main/java/com/rooster/rooster/util/AppConstants.kt
@@ -78,6 +78,13 @@ object AppConstants {
     // ========== Relative Time Strings ==========
     const val RELATIVE_TIME_PICK_TIME = "Pick Time"
     
+    // ========== Zenith Window ==========
+    // 432 seconds before to 432 seconds after solar noon — a 14m24s window
+    // for the zenith notification.
+    const val ZENITH_WINDOW_HALF_SECONDS = 432L
+    const val ZENITH_WINDOW_HALF_MS = ZENITH_WINDOW_HALF_SECONDS * MILLIS_PER_SECOND
+    const val ZENITH_WINDOW_TOTAL_MS = 2 * ZENITH_WINDOW_HALF_MS
+
     // ========== Solar Event Strings ==========
     const val SOLAR_EVENT_ASTRONOMICAL_DAWN = "Astronomical Dawn"
     const val SOLAR_EVENT_NAUTICAL_DAWN = "Nautical Dawn"

--- a/app/src/main/java/com/rooster/rooster/util/SolarEventScheduler.kt
+++ b/app/src/main/java/com/rooster/rooster/util/SolarEventScheduler.kt
@@ -101,6 +101,19 @@ object SolarEventScheduler {
         for ((event, time) in upcoming) {
             schedule(context, alarmManager, event, time)
         }
+
+        // If the zenith gong is enabled, also schedule the notification +
+        // tactile signature for ZENITH_WINDOW_HALF_MS before solar noon.
+        if (SolarEventPrefs.isZenithGongEnabled(context)) {
+            val noonTime = upcoming.firstOrNull { it.first == AppConstants.SOLAR_EVENT_SOLAR_NOON }?.second
+            if (noonTime != null) {
+                val windowStart = noonTime - AppConstants.ZENITH_WINDOW_HALF_MS
+                if (windowStart > now) {
+                    scheduleZenithWindow(context, alarmManager, windowStart)
+                }
+            }
+        }
+
         Logger.i(TAG, "Scheduled ${upcoming.size} upcoming solar event cue(s)")
     }
 
@@ -110,6 +123,10 @@ object SolarEventScheduler {
             val pi = pendingIntentFor(context, event, mutableFlag = false) ?: continue
             alarmManager.cancel(pi)
             pi.cancel()
+        }
+        zenithWindowPendingIntent(context, mutableFlag = false)?.let {
+            alarmManager.cancel(it)
+            it.cancel()
         }
     }
 
@@ -162,6 +179,43 @@ object SolarEventScheduler {
 
     private fun requestCodeFor(event: String): Int = REQUEST_CODE_BASE + EVENTS.indexOf(event)
 
+    private fun scheduleZenithWindow(
+        context: Context,
+        alarmManager: AlarmManager,
+        triggerAt: Long
+    ) {
+        val pi = zenithWindowPendingIntent(context, mutableFlag = true) ?: return
+        try {
+            val canExact = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                alarmManager.canScheduleExactAlarms()
+            } else {
+                true
+            }
+            if (canExact) {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pi)
+            } else {
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pi)
+            }
+            Logger.d(TAG, "Scheduled zenith window start at $triggerAt")
+        } catch (e: SecurityException) {
+            Logger.w(TAG, "Cannot schedule zenith window — permission denied", e)
+        } catch (e: Exception) {
+            Logger.e(TAG, "Failed to schedule zenith window", e)
+        }
+    }
+
+    private fun zenithWindowPendingIntent(context: Context, mutableFlag: Boolean): PendingIntent? {
+        val intent = Intent(context, SolarEventReceiver::class.java).apply {
+            action = SolarEventReceiver.ACTION_ZENITH_WINDOW_START
+        }
+        val flags = if (mutableFlag) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        }
+        return PendingIntent.getBroadcast(context, ZENITH_WINDOW_REQUEST_CODE, intent, flags)
+    }
+
     private fun eventTimes(data: AstronomyDataEntity): List<Pair<String, Long>> = listOf(
         AppConstants.SOLAR_EVENT_ASTRONOMICAL_DAWN to data.astroDawn,
         AppConstants.SOLAR_EVENT_NAUTICAL_DAWN     to data.nauticalDawn,
@@ -175,4 +229,5 @@ object SolarEventScheduler {
     )
 
     private const val REQUEST_CODE_BASE = 9_500
+    private const val ZENITH_WINDOW_REQUEST_CODE = 9_600
 }

--- a/app/src/main/java/com/rooster/rooster/util/ZenithNotification.kt
+++ b/app/src/main/java/com/rooster/rooster/util/ZenithNotification.kt
@@ -1,0 +1,59 @@
+package com.rooster.rooster.util
+
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.rooster.rooster.R
+import com.rooster.rooster.RoosterApplication
+
+/**
+ * Silent visual marker of the zenith window (-432s to +432s around solar
+ * noon). Posted on a LOW-importance channel so it carries no sound and no
+ * vibration of its own — the gong and its paired vibration handle the
+ * sensory moment at noon itself.
+ */
+object ZenithNotification {
+
+    const val NOTIFICATION_ID = 7432
+
+    fun show(context: Context) {
+        val notification = NotificationCompat.Builder(context, RoosterApplication.ZENITH_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Zenith approaching")
+            .setContentText("The sun is near its apex")
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setSilent(true)
+            .setOngoing(false)
+            .setAutoCancel(true)
+            .setTimeoutAfter(AppConstants.ZENITH_WINDOW_TOTAL_MS)
+            .build()
+
+        val manager = NotificationManagerCompat.from(context)
+        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context,
+                android.Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+        if (granted) {
+            runCatching { manager.notify(NOTIFICATION_ID, notification) }
+                .onFailure { Logger.e(TAG, "Failed to post zenith notification", it) }
+        } else {
+            Logger.w(TAG, "POST_NOTIFICATIONS not granted — skipping")
+        }
+    }
+
+    fun cancel(context: Context) {
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+        manager?.cancel(NOTIFICATION_ID)
+    }
+
+    private const val TAG = "ZenithNotification"
+}

--- a/app/src/main/java/com/rooster/rooster/util/ZenithVibration.kt
+++ b/app/src/main/java/com/rooster/rooster/util/ZenithVibration.kt
@@ -1,0 +1,54 @@
+package com.rooster.rooster.util
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+
+/**
+ * Unique tactile signature paired with the Zenith Sun Gong at solar noon —
+ * a three-step rise (low tap → mid pulse → long bright thrum) suggesting the
+ * sun climbing to its apex. Fires alongside the gong so the user still feels
+ * the moment when audio is suppressed (DND, silent, low volume).
+ *
+ * Distinct from [SolarEventVibration]'s tight "crown peal" which fires at
+ * noon only when general vibration is on.
+ */
+object ZenithVibration {
+
+    private val TIMINGS = longArrayOf(0, 120, 320, 220, 320, 420)
+    private val AMPLITUDES = intArrayOf(0, 90, 0, 170, 0, 230)
+
+    /** Total ms — used to keep the receiver alive while the pattern plays. */
+    fun durationMs(): Long = TIMINGS.sum()
+
+    fun vibrate(context: Context) {
+        val vibrator = obtainVibrator(context) ?: return
+        if (!vibrator.hasVibrator()) return
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val effect = if (vibrator.hasAmplitudeControl()) {
+                    VibrationEffect.createWaveform(TIMINGS, AMPLITUDES, -1)
+                } else {
+                    VibrationEffect.createWaveform(TIMINGS, -1)
+                }
+                vibrator.vibrate(effect)
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator.vibrate(TIMINGS, -1)
+            }
+        } catch (e: Exception) {
+            Logger.e("ZenithVibration", "Failed to fire zenith vibration", e)
+        }
+    }
+
+    private fun obtainVibrator(context: Context): Vibrator? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager)
+                ?.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+        }
+}


### PR DESCRIPTION
## Summary
- When **Zenith Sun Gong** is enabled, post a silent `LOW`-importance notification from **432s before to 432s after solar noon** (864s window centered on noon). Notification carries no sound and no vibration of its own — `setTimeoutAfter` auto-dismisses it at the end of the window.
- At solar noon itself, pair the gong with a unique tactile signature — a three-step rise (low tap → mid pulse → long thrum) that evokes the climb to apex. Replaces the standard noon "crown peal" vibration when the gong is on so the moment is felt even when audio is suppressed (DND, silent, low volume).
- Settings row for the Zenith Sun Gong is now tap-to-preview, so you can sample the gong without waiting until solar noon. Toggling it ON also fires one preview strike.

## Implementation notes
- New `ZENITH_CHANNEL_ID` (LOW importance, no vibration, no sound) created in `RoosterApplication`
- New `ZenithNotification` + `ZenithVibration` helpers
- Scheduler now schedules a separate `ACTION_ZENITH_WINDOW_START` broadcast at `solarNoon - 432s` when the gong is enabled, with its own PendingIntent (request code 9600) cancelled and recreated by `scheduleUpcoming` / `cancelAll`
- `ZENITH_WINDOW_HALF_SECONDS = 432` constant in `AppConstants`

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Pre-commit `./gradlew build` passes
- [ ] On-device: enable gong, tap row → confirm gong preview plays
- [ ] On-device: ~7m12s before next solar noon → notification appears, no vibration
- [ ] On-device: at solar noon → gong rings, unique zenith vibration fires
- [ ] On-device: ~7m12s after solar noon → notification auto-dismisses
- [ ] On-device: enable gong with phone in silent → still feel the vibration at noon

🤖 Generated with [Claude Code](https://claude.com/claude-code)