### PR TITLE
Route Zenith Sun Gong through USAGE_ALARM

### DIFF
--- a/app/src/main/java/com/rooster/rooster/util/ZenithGongTone.kt
+++ b/app/src/main/java/com/rooster/rooster/util/ZenithGongTone.kt
@@ -78,7 +78,7 @@ object ZenithGongTone {
             AudioTrack.Builder()
                 .setAudioAttributes(
                     AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
+                        .setUsage(AudioAttributes.USAGE_ALARM)
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .build()
                 )


### PR DESCRIPTION
## Summary
- Switch `ZenithGongTone`'s `AudioAttributes` from `USAGE_NOTIFICATION_EVENT` to `USAGE_ALARM`.
- The gong now rides alarm volume, plays through Do Not Disturb, and isn't suppressed by silent mode — matching the intent of the gong as the marquee zenith cue.

This is likely the real fix for the earlier "gong didn't ring" report: notification-event audio is silenced by DND/silent and rides the notification volume slider.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] Pre-commit `./gradlew build` passes
- [ ] On-device: enable gong with phone in silent → preview still plays
- [ ] On-device: enable gong with DND on → preview still plays
- [ ] On-device: confirm gong rings at solar noon

🤖 Generated with [Claude Code](https://claude.com/claude-code)