### PR TITLE
Bios design system polish + FAB and stepper fixes

### DIFF
--- a/app/src/main/java/com/rooster/rooster/presentation/compose/AlarmListScreen.kt
+++ b/app/src/main/java/com/rooster/rooster/presentation/compose/AlarmListScreen.kt
@@ -1,6 +1,5 @@
 package com.rooster.rooster.presentation.compose
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -10,12 +9,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
@@ -32,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -77,15 +74,10 @@ fun AlarmListScreen(
                     Icon(
                         painter = painterResource(R.drawable.add_alarm_button),
                         contentDescription = null,
+                        modifier = Modifier.size(24.dp),
                     )
                 },
-                text = {
-                    Text(
-                        text = "New Alarm",
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold,
-                    )
-                },
+                text = { Text(text = "New Alarm") },
             )
         },
     ) { innerPadding ->
@@ -96,10 +88,9 @@ fun AlarmListScreen(
         ) {
             if (sortedAlarms.isEmpty()) {
                 EmptyAlarmState(
-                    onCreateAlarm = onCreateAlarm,
                     modifier = Modifier
                         .align(Alignment.Center)
-                        .padding(40.dp),
+                        .padding(horizontal = 24.dp),
                 )
             } else {
                 AlarmList(
@@ -133,55 +124,26 @@ private fun AlarmList(
 }
 
 @Composable
-private fun EmptyAlarmState(
-    onCreateAlarm: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
+private fun EmptyAlarmState(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(
-                color = Color.Transparent,
-                shape = RoundedCornerShape(8.dp),
-            )
-            .padding(64.dp),
+        modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = "🌅", fontSize = 64.sp)
-        Spacer(modifier = Modifier.height(24.dp))
-        Text(
-            text = "No Alarms Yet",
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center,
-        )
+        Text(text = "🌅", fontSize = 40.sp)
         Spacer(modifier = Modifier.height(16.dp))
         Text(
-            text = "Create your first alarm to wake up naturally with the sun",
-            style = MaterialTheme.typography.bodyLarge,
+            text = "No Alarms Yet",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Tap New Alarm to wake up naturally with the sun",
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
             modifier = Modifier.alpha(0.9f),
         )
-        Spacer(modifier = Modifier.height(24.dp))
-        Button(
-            onClick = onCreateAlarm,
-            shape = RoundedCornerShape(8.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.primary,
-            ),
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.add_alarm_button),
-                contentDescription = null,
-            )
-            Spacer(modifier = Modifier.height(0.dp))
-            Text(
-                text = "  Create Alarm",
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold,
-            )
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Stop the **New Alarm FAB** from spanning the whole screen — `add_alarm_button.xml` is a 512×512dp vector, and Material 3's `Icon` only applies its 24dp default when the painter has no intrinsic size. Constrain the FAB icon to 24.dp and tighten the empty state (drop redundant CTA, smaller 🌅, calmer title weight).
- **Tighten alarm UI**: AlarmActivity Snooze/Stop buttons wrap_content with 140dp minWidth instead of weight-1 edge-to-edge; AlarmEditor stepper buttons swap circular OutlinedButton for filled 8dp-rounded surface-variant buttons matching the card radius identity.
- **Spacing + typography per Bios design system**: normalize dimens to the canonical 4/8/12/16/24/32/48 scale (drop unused 20/28/40 slots from base + sw480/sw600/sw720 variants); add `TextAppearance.Rooster.Instrument(.Small|.Large)` monospace styles for data-bearing text.
- **Route Zenith Sun Gong through `USAGE_ALARM`** so it plays at the alarm channel instead of media.
- Add `docs/DESIGN.md` summarizing the Bios design system, linked from the README.

## Test plan
- [ ] Fresh install (no alarms): verify the FAB renders as a normal pill at the bottom-right, not edge-to-edge.
- [ ] AlarmList with alarms: FAB still pill-shaped and tappable.
- [ ] Open AlarmEditor → Snooze panel: verify stepper +/- buttons are filled 40dp squares with 8dp radius.
- [ ] Trigger alarm: Snooze/Stop buttons sit centered with 140dp min width, no edge-to-edge stretch.
- [ ] Enable Zenith Sun Gong and trigger solar noon: gong plays through alarm channel (audible with media muted at alarm volume).
- [ ] Resize across sw480/sw600/sw720 device variants: layouts still readable, no broken references to dropped dimens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)