### PR TITLE
[patch] Fix solar noon DST drift + UI polish on Rooster branch

### DIFF
--- a/app/src/main/java/com/rooster/rooster/presentation/compose/SettingsScreen.kt
+++ b/app/src/main/java/com/rooster/rooster/presentation/compose/SettingsScreen.kt
@@ -845,11 +845,7 @@ private fun formatTimeOfDay(timeMillis: Long): String {
     if (timeMillis == 0L) return "--:--"
     val sdf = java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault())
     sdf.timeZone = java.util.TimeZone.getDefault()
-    val cal = java.util.Calendar.getInstance().apply { timeInMillis = timeMillis }
-    if (sdf.timeZone.inDaylightTime(cal.time)) {
-        cal.add(java.util.Calendar.MILLISECOND, sdf.timeZone.dstSavings)
-    }
-    return sdf.format(cal.time)
+    return sdf.format(java.util.Date(timeMillis))
 }
 
 private fun formatDayLength(dayLengthMillis: Long): String {

--- a/app/src/main/java/com/rooster/rooster/util/SolarCalculator.kt
+++ b/app/src/main/java/com/rooster/rooster/util/SolarCalculator.kt
@@ -32,21 +32,22 @@ object SolarCalculator {
 
         val jd = julianDay(year, month, day)
         val jc = julianCentury(jd)
+        val dateMs = date.timeInMillis
 
-        val solarNoonLST = solarNoonLocal(jc, longitude.toDouble(), timezone)
+        val solarNoonLST = solarNoonLocal(jc, longitude.toDouble(), timezone, dateMs)
         val solarNoonMs = timeToMillis(date, solarNoonLST)
 
-        val sunrise = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, ZENITH_OFFICIAL, true)
-        val sunset = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, ZENITH_OFFICIAL, false)
+        val sunrise = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, dateMs, ZENITH_OFFICIAL, true)
+        val sunset = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, dateMs, ZENITH_OFFICIAL, false)
 
-        val civilDawn = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, ZENITH_CIVIL, true)
-        val civilDusk = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, ZENITH_CIVIL, false)
+        val civilDawn = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, dateMs, ZENITH_CIVIL, true)
+        val civilDusk = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, dateMs, ZENITH_CIVIL, false)
 
-        val nauticalDawn = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, ZENITH_NAUTICAL, true)
-        val nauticalDusk = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, ZENITH_NAUTICAL, false)
+        val nauticalDawn = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, dateMs, ZENITH_NAUTICAL, true)
+        val nauticalDusk = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, dateMs, ZENITH_NAUTICAL, false)
 
-        val astroDawn = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, ZENITH_ASTRONOMICAL, true)
-        val astroDusk = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, ZENITH_ASTRONOMICAL, false)
+        val astroDawn = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, dateMs, ZENITH_ASTRONOMICAL, true)
+        val astroDusk = sunriseSet(jc, latitude.toDouble(), longitude.toDouble(), timezone, dateMs, ZENITH_ASTRONOMICAL, false)
 
         val sunriseMs = timeToMillis(date, sunrise)
         val sunsetMs = timeToMillis(date, sunset)
@@ -187,9 +188,9 @@ object SolarCalculator {
     /**
      * Calculate solar noon in local decimal hours.
      */
-    private fun solarNoonLocal(t: Double, longitude: Double, tz: TimeZone): Double {
+    private fun solarNoonLocal(t: Double, longitude: Double, tz: TimeZone, dateMillis: Long): Double {
         val eqTime = equationOfTime(t)
-        val offset = tz.rawOffset / 3600000.0 // hours
+        val offset = tz.getOffset(dateMillis) / 3600000.0 // hours, includes DST when in effect
         return (720.0 - 4 * longitude - eqTime + offset * 60) / 60.0
     }
 
@@ -198,21 +199,19 @@ object SolarCalculator {
      * @param isSunrise true for sunrise, false for sunset
      */
     private fun sunriseSet(
-        t: Double, lat: Double, lng: Double, tz: TimeZone,
+        t: Double, lat: Double, lng: Double, tz: TimeZone, dateMillis: Long,
         zenith: Double, isSunrise: Boolean
     ): Double {
         val eqTime = equationOfTime(t)
         val declin = sunDeclination(t)
         val ha = hourAngle(lat, declin, zenith)
+        val offset = tz.getOffset(dateMillis) / 3600000.0 // hours, includes DST when in effect
 
         if (ha.isNaN()) {
             // Polar day/night fallback: return solar noon ± 0 (event doesn't occur)
-            val offset = tz.rawOffset / 3600000.0
-            val noon = (720.0 - 4 * lng - eqTime + offset * 60) / 60.0
-            return noon
+            return (720.0 - 4 * lng - eqTime + offset * 60) / 60.0
         }
 
-        val offset = tz.rawOffset / 3600000.0 // hours
         return if (isSunrise) {
             (720.0 - 4 * (lng + ha) - eqTime + offset * 60) / 60.0
         } else {

--- a/app/src/test/java/com/rooster/rooster/util/SolarCalculatorTest.kt
+++ b/app/src/test/java/com/rooster/rooster/util/SolarCalculatorTest.kt
@@ -11,8 +11,7 @@ import java.util.TimeZone
  */
 class SolarCalculatorTest {
 
-    // Tolerance: 15 minutes in milliseconds (accounts for equation-of-time drift
-    // and the fact that SolarCalculator uses rawOffset, ignoring DST)
+    // Tolerance: 15 minutes in milliseconds (covers equation-of-time drift across a year)
     private val TOLERANCE_MS = 15 * 60 * 1000L
 
     private fun calendarFor(year: Int, month: Int, day: Int, tz: TimeZone): Calendar {
@@ -69,9 +68,8 @@ class SolarCalculatorTest {
         val date = calendarFor(2025, 6, 21, tz)
         val result = SolarCalculator.calculate(40.7128f, -74.006f, date)
 
-        // Note: SolarCalculator uses rawOffset (EST=-5) not EDT=-4, so times are 1h earlier
-        val expectedSunrise = millisForTime(date, 4, 25) // ~5:25 EDT - 1h DST offset
-        val expectedSunset = millisForTime(date, 19, 31)  // ~20:31 EDT - 1h DST offset
+        val expectedSunrise = millisForTime(date, 5, 25) // ~5:25 EDT
+        val expectedSunset = millisForTime(date, 20, 31)  // ~20:31 EDT
 
         assertEquals("NYC summer solstice sunrise", expectedSunrise.toDouble(), result.sunrise.toDouble(), TOLERANCE_MS.toDouble())
         assertEquals("NYC summer solstice sunset", expectedSunset.toDouble(), result.sunset.toDouble(), TOLERANCE_MS.toDouble())


### PR DESCRIPTION
## Summary

This branch bundles six commits that accumulated since the last merge to `main`. The headline fix is the solar-noon DST bug; the rest is UI tightening and the Bios design-doc.

### Fixes
- **Solar event times drifting by 1 h during DST.** `SolarCalculator` used `TimeZone.rawOffset`, ignoring DST, so events were stored 1 h before the true wall-clock time. `SettingsScreen.formatTimeOfDay` layered a manual `dstSavings` adjustment on top of a `SimpleDateFormat` that already converts to local time, drifting the display 1 h the other way. Net effect: the alarm fired an hour before the time shown in settings (e.g. settings → 13:48, gong → 12:48). Both sites fixed; tests updated.
- **Zenith Sun Gong routed through `USAGE_ALARM`** so it plays at alarm volume.

### UI / Design
- Align spacing scale and add Instrument typography per Bios design system.
- Tighten Alarm screen and Alarm Editor stepper buttons.
- Stop "New Alarm" FAB from spanning the screen.
- Add `docs/DESIGN.md` and link from README.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --rerun-tasks` — all SolarCalculator tests pass with DST-aware expectations
- [x] Pre-commit `./gradlew build` passes
- [ ] On-device: set system clock to a DST date, confirm Solar Noon row in Settings matches the time the gong actually fires
- [ ] Verify Alarm screen + Alarm Editor stepper layout on phone and small-width tablet
- [ ] Verify "New Alarm" FAB no longer stretches edge-to-edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)